### PR TITLE
fix invalid syntax

### DIFF
--- a/syntax/cp2k.vim
+++ b/syntax/cp2k.vim
@@ -61,7 +61,6 @@ syn match cp2kComment "!.*$" contains=cp2kTodo
 " CP2K predefined constants
 "----------------------------------------------------------------/
 
-syn keyword cp2kConstant 
 syn keyword cp2kConstant -X
 syn keyword cp2kConstant -Y
 syn keyword cp2kConstant -Z


### PR DESCRIPTION
I believe `cp2k_input.xml` had something like `<NAME/>`.

cp2k.ssmp (cp2k/cp2k@6ed042cac1087e89817c5d0b274f19b5d88e6367; GCC, with FFTW and OpenBLAS only) does not give such an element, so I’m not sure where it came from.

A naive solution is to remove the line.